### PR TITLE
IE Fixes 

### DIFF
--- a/addon/components/create-overlay.js
+++ b/addon/components/create-overlay.js
@@ -89,12 +89,15 @@ export default Component.extend({
 
   actions: {
     beginHover() {
+      console.log('BEGIN HOVER');
       this.set('hovered', true);
     },
     endHover() {
+      console.log('END HOVER');
       this.set('hovered', false);
     },
     targetClicked() {
+      console.log('TARGET CLICKED');
       let handler = this.get('onclick');
       if (handler) {
         handler();

--- a/addon/components/create-overlay.js
+++ b/addon/components/create-overlay.js
@@ -89,15 +89,12 @@ export default Component.extend({
 
   actions: {
     beginHover() {
-      console.log('BEGIN HOVER');
       this.set('hovered', true);
     },
     endHover() {
-      console.log('END HOVER');
       this.set('hovered', false);
     },
     targetClicked() {
-      console.log('TARGET CLICKED');
       let handler = this.get('onclick');
       if (handler) {
         handler();

--- a/addon/mark-info.js
+++ b/addon/mark-info.js
@@ -13,7 +13,7 @@ export default class MarkInfo {
     r.setStartBefore(this._firstNode);
     r.setEndAfter(this._lastNode);
     let boundingRect = r.getBoundingClientRect();
-    if (boundingRect.height === 0 && boundingRect.width === 0) return this._firstNode.getBoundingClientRect()
+    if (boundingRect.height === 0 && boundingRect.width === 0) return this._firstNode.getBoundingClientRect();
     return boundingRect;
   }
 

--- a/addon/mark-info.js
+++ b/addon/mark-info.js
@@ -9,10 +9,12 @@ export default class MarkInfo {
 
   bounds() {
     if (!this._firstNode.parentNode || !this._lastNode.parentNode) { return; }
-    let r = new Range();
+    let r = document.createRange();
     r.setStartBefore(this._firstNode);
     r.setEndAfter(this._lastNode);
-    return r.getBoundingClientRect();
+    let boundingRect = r.getBoundingClientRect();
+    if (boundingRect.height === 0 && boundingRect.width === 0) return this._firstNode.getBoundingClientRect()
+    return boundingRect;
   }
 
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -12,7 +12,7 @@
 }
 
 .show-overlay.reveal {
-    visibility: initial;
+    visibility: visible;
 }
 
 .show-overlay.focused {
@@ -44,7 +44,7 @@
     /* Only the target area itself is visible initially, and it
        doesn't have any content. But this makes it eligible for
        mouse events. */
-    visibility: initial;
+    visibility: visible;
 }
 
 .overlay-scrim {


### PR DESCRIPTION
- IE 11 doesn't support `visibility: initial`
- IE 11 doesn't support the `Range` constructor
- Edge and IE have a bug with `getBoundingClientRect` that returns 0 height and width for some elements, so we check the first node's rect too

@0xadada 