### PR TITLE
Reverse overlays option, oversized overlays option

### DIFF
--- a/addon/components/create-overlay.js
+++ b/addon/components/create-overlay.js
@@ -38,16 +38,16 @@ export default Component.extend({
     }
   },
 
-  _translation(targetRect, ownRect, currentTransform) {
-    return `translateX(${targetRect.left - ownRect.left + currentTransform.tx}px) translateY(${targetRect.top - ownRect.top + currentTransform.ty}px)`;
+  _translation(targetRect, ownRect, currentTransform, oversized) {
+    return `translateX(${targetRect.left - ownRect.left + currentTransform.tx - (oversized ? 20 : 5)}px) translateY(${targetRect.top - ownRect.top + currentTransform.ty - (oversized ? 20 : 5)}px)`;
   },
 
-  _matchWidth($elt, targetRect, ownRect) {
-    return `${$elt.outerWidth() + targetRect.right - targetRect.left - ownRect.right + ownRect.left}px`;
+  _matchWidth($elt, targetRect, ownRect, oversized) {
+    return `${$elt.outerWidth() + targetRect.right - targetRect.left - ownRect.right + ownRect.left + (oversized ? 40 : 10)}px`;
   },
 
-  _matchHeight($elt, targetRect, ownRect) {
-    return `${$elt.outerHeight() + targetRect.bottom - targetRect.top - ownRect.bottom + ownRect.top}px`;
+  _matchHeight($elt, targetRect, ownRect, oversized) {
+    return `${$elt.outerHeight() + targetRect.bottom - targetRect.top - ownRect.bottom + ownRect.top + (oversized ? 40 : 10)}px`;
   },
 
   _track: task(function * () {
@@ -64,14 +64,18 @@ export default Component.extend({
         // position ourselves over the target
         let ownRect = $ownTarget[0].getBoundingClientRect();
         let t = ownTransform($elt[0]);
+        const oversized = this.get('oversized');
+
         $elt.css({
           display: 'initial',
-          transform: `${this._translation(targetRect, ownRect, t)} scale(${this.get('fieldScale')})`
+          transform: `${this._translation(targetRect, ownRect, t, oversized)} scale(${this.get('fieldScale')})`
         });
+
         $ownTarget.css({
-          width: this._matchWidth($ownTarget, targetRect, ownRect),
-          minHeight: this._matchHeight($ownTarget, targetRect, ownRect),
+          width: this._matchWidth($ownTarget, targetRect, ownRect, oversized),
+          minHeight: this._matchHeight($ownTarget, targetRect, ownRect, oversized),
         });
+
         $elt.find('> label').css({
           transform: `translateY(-100%) scale(${1 / this.get('fieldScale')})`
         });

--- a/addon/components/create-overlay.js
+++ b/addon/components/create-overlay.js
@@ -38,16 +38,16 @@ export default Component.extend({
     }
   },
 
-  _translation(targetRect, ownRect, currentTransform, oversized) {
-    return `translateX(${targetRect.left - ownRect.left + currentTransform.tx - (oversized ? 20 : 5)}px) translateY(${targetRect.top - ownRect.top + currentTransform.ty - (oversized ? 20 : 5)}px)`;
+  _translation(targetRect, ownRect, currentTransform, expandSizeBy) {
+    return `translateX(${targetRect.left - ownRect.left + currentTransform.tx - (expandSizeBy ? expandSizeBy / 2 : 5)}px) translateY(${targetRect.top - ownRect.top + currentTransform.ty - (expandSizeBy ? expandSizeBy / 2 : 5)}px)`;
   },
 
-  _matchWidth($elt, targetRect, ownRect, oversized) {
-    return `${$elt.outerWidth() + targetRect.right - targetRect.left - ownRect.right + ownRect.left + (oversized ? 40 : 10)}px`;
+  _matchWidth($elt, targetRect, ownRect, expandSizeBy) {
+    return `${$elt.outerWidth() + targetRect.right - targetRect.left - ownRect.right + ownRect.left + (expandSizeBy ? expandSizeBy : 10)}px`;
   },
 
-  _matchHeight($elt, targetRect, ownRect, oversized) {
-    return `${$elt.outerHeight() + targetRect.bottom - targetRect.top - ownRect.bottom + ownRect.top + (oversized ? 40 : 10)}px`;
+  _matchHeight($elt, targetRect, ownRect, expandSizeBy) {
+    return `${$elt.outerHeight() + targetRect.bottom - targetRect.top - ownRect.bottom + ownRect.top + (expandSizeBy ? expandSizeBy : 10)}px`;
   },
 
   _track: task(function * () {
@@ -64,16 +64,16 @@ export default Component.extend({
         // position ourselves over the target
         let ownRect = $ownTarget[0].getBoundingClientRect();
         let t = ownTransform($elt[0]);
-        const oversized = this.get('oversized');
+        const expandSizeBy = this.get('expandSizeBy');
 
         $elt.css({
           display: 'initial',
-          transform: `${this._translation(targetRect, ownRect, t, oversized)} scale(${this.get('fieldScale')})`
+          transform: `${this._translation(targetRect, ownRect, t, expandSizeBy)} scale(${this.get('fieldScale')})`
         });
 
         $ownTarget.css({
-          width: this._matchWidth($ownTarget, targetRect, ownRect, oversized),
-          minHeight: this._matchHeight($ownTarget, targetRect, ownRect, oversized),
+          width: this._matchWidth($ownTarget, targetRect, ownRect, expandSizeBy),
+          minHeight: this._matchHeight($ownTarget, targetRect, ownRect, expandSizeBy),
         });
 
         $elt.find('> label').css({

--- a/addon/components/overlay-marks.js
+++ b/addon/components/overlay-marks.js
@@ -7,9 +7,10 @@ export default Component.extend({
   layout,
   tagName: '',
   service: service('ember-overlays'),
-  marks: computed('service.marks', function() {
+  marks: computed('service.marks', 'reverseOrder', function() {
     let group = this.get('group') || 'default';
     let id = this.get('id');
-    return this.get('service.marks').filter(m => m.group === group && (id == null || m.id === id));
+    const marks = this.get('service.marks').filter(m => m.group === group && (id == null || m.id === id))
+    return this.get('reverseOrder') ? marks.slice(0).reverse() : marks;
   })
 });

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -33,7 +33,7 @@
 }
 
 .overlay-border {
-    padding: 10px;
+    /* padding: 10px; */
     border: 2px solid #63A9FA;
     width: 100%;
     height: 100%;

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -26,7 +26,7 @@
     padding: 0.2em 1.5em 0em;
     position: absolute;
     white-space: nowrap;
-    top: 2px;
+    top: 0;
     transform-origin: bottom left;
     background-color: #63A9FA;
     color: white;

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -33,7 +33,6 @@
 }
 
 .overlay-border {
-    /* padding: 10px; */
     border: 2px solid #63A9FA;
     width: 100%;
     height: 100%;

--- a/tests/integration/components/create-overlay-test.js
+++ b/tests/integration/components/create-overlay-test.js
@@ -16,8 +16,8 @@ test('it renders without block', function(assert) {
     {{/overlay-marks}}
   `);
   assert.equal(this.$('label:contains(my overlay)').length, 1);
-  assert.equal(this.$('.my-overlay .target').width(), 100);
-  assert.equal(this.$('.my-overlay .target').height(), 200);
+  assert.equal(this.$('.my-overlay .target').width(), 110);
+  assert.equal(this.$('.my-overlay .target').height(), 210);
 });
 
 test('it renders with a custom label component', function(assert) {
@@ -51,8 +51,8 @@ test('it renders with user content', function(assert) {
     {{/overlay-marks}}
   `);
   assert.equal(this.$('.user-content').length, 1);
-  assert.equal(this.$('.my-overlay .target').width(), 100);
-  assert.equal(this.$('.my-overlay .target').height(), 200);
+  assert.equal(this.$('.my-overlay .target').width(), 110);
+  assert.equal(this.$('.my-overlay .target').height(), 210);
 });
 
 test('it renders with user content taller than underlying mark', function(assert) {
@@ -67,6 +67,20 @@ test('it renders with user content taller than underlying mark', function(assert
     {{/overlay-marks}}
   `);
   assert.equal(this.$('.user-content').length, 1);
-  assert.equal(this.$('.my-overlay .target').width(), 100);
+  assert.equal(this.$('.my-overlay .target').width(), 110);
   assert.equal(this.$('.my-overlay .target').height(), 300);
+});
+
+test('it renders oversized', function(assert) {
+  this.render(hbs`
+    {{#mark-overlay id="my-mark-id"}}
+      <div class="test-target" style="width: 100px; height: 200px"></div>
+    {{/mark-overlay}}
+    {{#overlay-marks as |mark|}}
+      {{create-overlay at=mark highlighted=true oversized=true label="my overlay" class="my-overlay"}}
+    {{/overlay-marks}}
+  `);
+  assert.equal(this.$('label:contains(my overlay)').length, 1);
+  assert.equal(this.$('.my-overlay .target').width(), 140);
+  assert.equal(this.$('.my-overlay .target').height(), 240);
 });

--- a/tests/integration/components/create-overlay-test.js
+++ b/tests/integration/components/create-overlay-test.js
@@ -71,13 +71,13 @@ test('it renders with user content taller than underlying mark', function(assert
   assert.equal(this.$('.my-overlay .target').height(), 300);
 });
 
-test('it renders oversized', function(assert) {
+test('it renders larger overlays', function(assert) {
   this.render(hbs`
     {{#mark-overlay id="my-mark-id"}}
       <div class="test-target" style="width: 100px; height: 200px"></div>
     {{/mark-overlay}}
     {{#overlay-marks as |mark|}}
-      {{create-overlay at=mark highlighted=true oversized=true label="my overlay" class="my-overlay"}}
+      {{create-overlay at=mark highlighted=true expandSizeBy=40 label="my overlay" class="my-overlay"}}
     {{/overlay-marks}}
   `);
   assert.equal(this.$('label:contains(my overlay)').length, 1);

--- a/tests/integration/components/overlay-marks-test.js
+++ b/tests/integration/components/overlay-marks-test.js
@@ -41,3 +41,37 @@ test('it ignores marks with other types', function(assert) {
   `);
   assert.equal(this.$('.test-overlay').length, 0, 'should find none');
 });
+
+test('it renders the marks in the order they are registered', function(assert) {
+  this.render(hbs`
+    {{#mark-overlay group="other" id="my-mark-id-1"}}
+      <div class="test-target"></div>
+    {{/mark-overlay}}
+    {{#mark-overlay group="other" id="my-mark-id-2"}}
+      <div class="test-target"></div>
+    {{/mark-overlay}}
+    {{#overlay-marks group="other" as |mark|}}
+      <div class="test-overlay">{{mark.id}}</div>
+    {{/overlay-marks}}
+  `);
+  assert.equal(this.$('.test-overlay').length, 2, 'finds 2 marks');
+  assert.equal(this.$('.test-overlay').first().text(), 'my-mark-id-1', 'finds 1 mark first');
+  assert.equal(this.$('.test-overlay').last().text(), 'my-mark-id-2', 'finds 2 mark second');
+});
+
+test('it reverses the order of the marks', function(assert) {
+  this.render(hbs`
+    {{#mark-overlay group="other" id="my-mark-id-1"}}
+      <div class="test-target"></div>
+    {{/mark-overlay}}
+    {{#mark-overlay group="other" id="my-mark-id-2"}}
+      <div class="test-target"></div>
+    {{/mark-overlay}}
+    {{#overlay-marks group="other" reverseOrder=true as |mark|}}
+      <div class="test-overlay">{{mark.id}}</div>
+    {{/overlay-marks}}
+  `);
+  assert.equal(this.$('.test-overlay').length, 2, 'finds 2 marks');
+  assert.equal(this.$('.test-overlay').first().text(), 'my-mark-id-2', 'finds 2nd mark first');
+  assert.equal(this.$('.test-overlay').last().text(), 'my-mark-id-1', 'finds 1st mark second');
+});


### PR DESCRIPTION
Adds:
- Ability to reverse overlay marks so multiple layers of components can still have overlays that are hoverable
- Ability to expand over marks by a number of pixels with `expandSizeBy`