### PR TITLE
filter out pointer events

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -30,6 +30,7 @@
     transform-origin: bottom left;
     background-color: #63A9FA;
     color: white;
+    pointer-events: none;
 }
 
 .overlay-border {


### PR DESCRIPTION
This change allows pointer events to be ignored by label elements with the `.overlay-label` class so that the surrounding overlay border does not flicker.