### PR TITLE
fix for ember 2.16

### DIFF
--- a/addon/templates/components/create-overlay.hbs
+++ b/addon/templates/components/create-overlay.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable no-invalid-interactive --}}
 {{#if labelComponent}}
-  {{labelComponent}}
+  {{component labelComponent}}
 {{else if label}}
   <label class="overlay-label">{{label}}</label>
 {{/if}}


### PR DESCRIPTION
After much debugging on older versions of Ember (2.16 and LTS 2.18), i found this tiny lil fix to make it backwards compatible. 

In modern ember if you pass a component in as an atrribute, you can just invoke it:
```hbs
{{a labelComponent=(component "b")}}
...
  {{labelComponent}}
```

in older Ember you've got to use the component helper
```hbs
{{a labelComponent=(component "b")}}
...
  {{component labelComponent}}
```